### PR TITLE
Fix rad_group_switch synopsis text

### DIFF
--- a/docs/content/reference/cli/rad_group_switch.md
+++ b/docs/content/reference/cli/rad_group_switch.md
@@ -14,11 +14,11 @@ Switch default resource group scope
 
 Switch default resource group scope
 	
-	Radius workspaces contain a resource group scope, where Radius Applications and resources are deployed by default. The switch command changes the default scope of the workspace to the specified resource group name.
+Radius workspaces contain a resource group scope, where Radius Applications and resources are deployed by default. The switch command changes the default scope of the workspace to the specified resource group name.
 	
-	Resource groups are used to organize and manage Radius resources. They often contain resources that share a common lifecycle or unit of deployment.
+Resource groups are used to organize and manage Radius resources. They often contain resources that share a common lifecycle or unit of deployment.
 			
-	Note that these resource groups are separate from the Azure cloud provider and Azure resource groups configured with the cloud provider.
+Note that these resource groups are separate from the Azure cloud provider and Azure resource groups configured with the cloud provider.
 
 ```
 rad group switch resourcegroupname [flags]


### PR DESCRIPTION
Fix the synopsis text formatting from a code block to a regular text block.

Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The rad group switch page currently uses code formatting for the synopsis text. This PR fixes the formatting.

![image](https://github.com/user-attachments/assets/5f456e77-0304-4368-a72c-06256ddc3ab8)


## Issue reference

Fixes: N/A
